### PR TITLE
Add missing ls

### DIFF
--- a/src/bash/crayons.sh
+++ b/src/bash/crayons.sh
@@ -22,9 +22,9 @@ rgb () {
     [[ $colour_ =~ ^l ]] && light_=1
     [[ $light_ ]] && colour_=${colour_:1}
     colour_=${colour_^^}
-    local ight_=NIGHT_
-    [[ $light_ ]] && ight_=LIGHT_
-    local foreground_="$ight_$colour_" background_=
+    local light_=NIGHT_
+    [[ $light_ ]] && light_=LIGHT_
+    local foreground_="$light_$colour_" background_=
     if [[ $1 =~ ^(red|green|blue|cyan|magenta|black|white)$ ]]; then
         background_="BACK_${1^^}"
         shift


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the typo in the rgb function by renaming 'ight_' to 'light_' for setting the color prefix.