### PR TITLE
Show commmand as a full line

### DIFF
--- a/src/bash/crayons.sh
+++ b/src/bash/crayons.sh
@@ -88,6 +88,7 @@ show_command () {
         [[ $arg_ =~ \  ]] && arg_="\"$arg_\""
         lblue "$arg_ "
     done
+    echo
 }
 
 show_run_command () {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix show_command output so printed commands are followed by a newline instead of continuing on the same line.